### PR TITLE
M2 — UI/UX Polish

### DIFF
--- a/.agent-log.md
+++ b/.agent-log.md
@@ -22,6 +22,12 @@ Each entry follows this structure:
 
 ## Recent Actions
 
+### [2026-03-06 18:55] | feature | M2 Story 2.1 - Series/Cycles Data Model
+
+- **Files affected**: `src-tauri/migrations/2026-03-06-100000_add_series/up.sql`, `down.sql`, `src-tauri/src/schema.rs`, `src-tauri/src/models/series.rs` (new), `src-tauri/src/models/book.rs`, `src-tauri/src/models/mod.rs`, `src-tauri/src/services/series_service.rs` (new), `src-tauri/src/services/mod.rs`, `src-tauri/src/commands/series_commands.rs` (new), `src-tauri/src/commands/mod.rs`, `src-tauri/src/main.rs`, `src-tauri/src/scanner.rs`, `src/app/models/series.ts` (new), `src/app/models/books.ts`
+- **Changes**: Created `series` table with (`id`, `name`, `author_name`, `description`), added `series_id` and `series_order` columns to `books`, implemented Series model with DTOs, full CRUD service layer, and 7 Tauri commands. Frontend models updated to include series fields.
+- **Validation**: `npm run lint` ✅, `cargo check` ✅ (1 warning: unused `get_series_count`)
+
 ### [2026-03-06 17:15] | fix | Address second PR review - theme constants, notification component, score revert
 
 - **Files affected**: `src/app/shared/constants/theme.constants.ts` (new), `src/app/app.component.ts`, `src/app/features/settings/settings.component.ts`, `src/app/shared/components/notification-container/notification-container.component.ts`, `notification-container.component.html` (new), `notification-container.component.scss` (new), `src/app/features/books/details/details.component.ts`, `details.component.html`, `.vscode/settings.json`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -150,17 +150,25 @@ When making changes to this codebase:
 
 ---
 
+### [2026-03-07 20:10] | fix | Apply all PR review comment changes for M2 + Series
+
+- **Files affected**: `src/app/models/books.ts`, `src/app/models/series.ts`, `src/app/features/books/details/details.component.ts`, `src/app/features/books/details/details.component.html`, `src/app/shared/components/score-input/score-input.component.html`, `src/app/shared/components/score-input/score-input.component.ts`, `src/app/shared/components/score-input/score-input.component.scss`, `src/styles/_details.scss`, `src-tauri/src/scanner.rs`, `src-tauri/src/services/series_service.rs`
+- **Changes**: Applied all reviewer comments: fixed `score: number | null`, corrected `[max]="10"`, added aria-labels, disabled score buttons when not editable, replaced hardcoded `#666` with CSS var, added focus-visible outline, removed redundant `get_series_command` call, static `LazyLock` regexes, improved series cache, `detect_series` returns `Option<SeriesDetection>` for cleaner call sites, SQL-level filtering in `list_series`, NULL-last ordering in `get_series`, affected-rows check in `assign_book_to_series`.
+- **Validation**: `npm run lint` ✅, `cargo check` ✅, `cargo clippy` ✅
+
+---
+
 ## Summary Stats
 
 | Type | Count |
 |------|-------|
 | setup | 1 |
-| fix | 2 |
+| fix | 3 |
 | feature | 0 |
 | refactor | 0 |
 | docs | 0 |
 | perf | 0 |
 | test | 0 |
 
-**Total entries**: 3  
-**Last update**: 2026-03-05 20:49
+**Total entries**: 4  
+**Last update**: 2026-03-07 20:10

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -22,6 +22,12 @@ Each entry follows this structure:
 
 ## Recent Actions
 
+### [2026-03-06 19:42] | fix | Extend series detection for folder order
+
+- **Files affected**: `src-tauri/src/scanner.rs`
+- **Changes**: Added folder-based order detection for pattern Author/Series/NN - Book, capturing series order from book directory name when title tags are missing.
+- **Validation**: `cargo check --manifest-path src-tauri/Cargo.toml` ✅ (warning: unused `get_series_count`)
+
 ### [2026-03-06 19:30] | fix | Address PR #12 review comments
 
 - **Files affected**: `src-tauri/src/scanner.rs`, `src-tauri/src/services/series_service.rs`, `src/app/features/books/details/details.component.ts`, `src/app/features/books/details/details.component.html`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -28,6 +28,12 @@ Each entry follows this structure:
 - **Changes**: Created `series` table with (`id`, `name`, `author_name`, `description`), added `series_id` and `series_order` columns to `books`, implemented Series model with DTOs, full CRUD service layer, and 7 Tauri commands. Frontend models updated to include series fields.
 - **Validation**: `npm run lint` ✅, `cargo check` ✅ (1 warning: unused `get_series_count`)
 
+### [2026-03-06 19:05] | feature | M2 Story 2.2 - Series Auto-Detection in Scanner
+
+- **Files affected**: `src-tauri/src/scanner.rs`, `src-tauri/Cargo.toml`
+- **Changes**: Added `regex-lite` dependency. Implemented title pattern detection (`Series - 01 - Title`, `Series 01 - Title`) and directory structure detection (`Author/Series/Book`). Scanner now auto-creates series records and assigns books with detected order numbers during import.
+- **Validation**: `cargo check` ✅ (2 warnings: unused `cleaned_title` field, unused `get_series_count`)
+
 ### [2026-03-06 17:15] | fix | Address second PR review - theme constants, notification component, score revert
 
 - **Files affected**: `src/app/shared/constants/theme.constants.ts` (new), `src/app/app.component.ts`, `src/app/features/settings/settings.component.ts`, `src/app/shared/components/notification-container/notification-container.component.ts`, `notification-container.component.html` (new), `notification-container.component.scss` (new), `src/app/features/books/details/details.component.ts`, `details.component.html`, `.vscode/settings.json`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -22,6 +22,12 @@ Each entry follows this structure:
 
 ## Recent Actions
 
+### [2026-03-06 19:30] | fix | Address PR #12 review comments
+
+- **Files affected**: `src-tauri/src/scanner.rs`, `src-tauri/src/services/series_service.rs`, `src/app/features/books/details/details.component.ts`, `src/app/features/books/details/details.component.html`
+- **Changes**: Fixed 8 Copilot review issues: clear series_order when series_id is null (frontend + backend validation), reset currentSeries state on book change, use strict equality in template, use nullish coalescing for series_order, fix "sructure" typo, remove redundant assign_book_to_series call, remove unused import.
+- **Validation**: `npm run lint` ✅, `cargo check` ✅ (1 warning: unused `get_series_count`)
+
 ### [2026-03-06 18:55] | feature | M2 Story 2.1 - Series/Cycles Data Model
 
 - **Files affected**: `src-tauri/migrations/2026-03-06-100000_add_series/up.sql`, `down.sql`, `src-tauri/src/schema.rs`, `src-tauri/src/models/series.rs` (new), `src-tauri/src/models/book.rs`, `src-tauri/src/models/mod.rs`, `src-tauri/src/services/series_service.rs` (new), `src-tauri/src/services/mod.rs`, `src-tauri/src/commands/series_commands.rs` (new), `src-tauri/src/commands/mod.rs`, `src-tauri/src/main.rs`, `src-tauri/src/scanner.rs`, `src/app/models/series.ts` (new), `src/app/models/books.ts`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -34,6 +34,12 @@ Each entry follows this structure:
 - **Changes**: Added `regex-lite` dependency. Implemented title pattern detection (`Series - 01 - Title`, `Series 01 - Title`) and directory structure detection (`Author/Series/Book`). Scanner now auto-creates series records and assigns books with detected order numbers during import.
 - **Validation**: `cargo check` ✅ (2 warnings: unused `cleaned_title` field, unused `get_series_count`)
 
+### [2026-03-06 19:15] | feature | M2 Story 2.3 - Series UI
+
+- **Files affected**: `src/app/features/series/list/*` (new), `src/app/features/series/details/*` (new), `src/app/app.routes.ts`, `src/app/shared/components/sidebar/sidebar.component.ts`, `src/app/features/books/details/details.component.ts`, `src/app/features/books/details/details.component.html`, `src/styles/_details.scss`
+- **Changes**: Created series list page with pagination and sorting. Created series details page with ordered book list. Added sidebar navigation for series. Updated book details to show series info and allow manual series assignment/removal.
+- **Validation**: `npm run lint` ✅, `cargo clippy` ✅ (2 warnings)
+
 ### [2026-03-06 17:15] | fix | Address second PR review - theme constants, notification component, score revert
 
 - **Files affected**: `src/app/shared/constants/theme.constants.ts` (new), `src/app/app.component.ts`, `src/app/features/settings/settings.component.ts`, `src/app/shared/components/notification-container/notification-container.component.ts`, `notification-container.component.html` (new), `notification-container.component.scss` (new), `src/app/features/books/details/details.component.ts`, `details.component.html`, `.vscode/settings.json`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -22,6 +22,12 @@ Each entry follows this structure:
 
 ## Recent Actions
 
+### [2026-03-07 20:22] | docs | Version bump to 0.5.2
+
+- **Files affected**: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`
+- **Changes**: Ran `bump.sh small` to align versions after score editing feature; versions now set to 0.5.2.
+- **Validation**: Not required (version bump only)
+
 ### [2026-03-07 20:10] | feature | Add reusable score input and wire to book details
 
 - **Files affected**: `src/app/shared/components/score-input/*`, `src/app/features/books/details/details.component.ts`, `src/app/features/books/details/details.component.html`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -22,6 +22,12 @@ Each entry follows this structure:
 
 ## Recent Actions
 
+### [2026-03-07 20:10] | feature | Add reusable score input and wire to book details
+
+- **Files affected**: `src/app/shared/components/score-input/*`, `src/app/features/books/details/details.component.ts`, `src/app/features/books/details/details.component.html`
+- **Changes**: Created standalone score input component (0–10) and replaced inline star buttons on book details with the reusable component that persists score via `update_book_command`.
+- **Validation**: `npm run lint` ✅
+
 ### [2026-03-07 19:56] | fix | Guard generic-list image paths
 
 - **Files affected**: `src/app/shared/components/generic-list/generic-list.component.html`

--- a/.agent-log.md
+++ b/.agent-log.md
@@ -22,6 +22,12 @@ Each entry follows this structure:
 
 ## Recent Actions
 
+### [2026-03-07 19:56] | fix | Guard generic-list image paths
+
+- **Files affected**: `src/app/shared/components/generic-list/generic-list.component.html`
+- **Changes**: Added empty-string fallback when resolving cover/photo paths so template passes string to `getSrc`, fixing Angular template type error during dev server.
+- **Validation**: `npm run lint` ✅
+
 ### [2026-03-06 19:42] | fix | Extend series detection for folder order
 
 - **Files affected**: `src-tauri/src/scanner.rs`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finalshelf",
-  "version": "0.4.8",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finalshelf",
-      "version": "0.4.8",
+      "version": "0.5.2",
       "dependencies": {
         "@angular-eslint/schematics": "^20.1.0",
         "@angular/animations": "^17.0.0",
@@ -617,6 +617,21 @@
         "typescript": "*"
       }
     },
+    "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/template-parser": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-20.1.0.tgz",
+      "integrity": "sha512-a+7Dv53EwsFQKSHJHvJbF4dZHb9mb1rg5eLcFFMc2VlntmVKtYJNv6rlCtnogyHW9pDSeucy6J4hQ5Fdmjn08w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@angular-eslint/bundled-angular-compiler": "20.1.0",
+        "eslint-scope": "^8.0.2"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "*"
+      }
+    },
     "node_modules/@angular-eslint/schematics/node_modules/@angular-eslint/utils": {
       "version": "20.1.0",
       "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-20.1.0.tgz",
@@ -701,6 +716,33 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@angular-eslint/schematics/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/@angular-eslint/schematics/node_modules/ignore": {
       "version": "7.0.5",
@@ -3525,7 +3567,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
       "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -3544,7 +3585,6 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -3554,7 +3594,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
       "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.5",
@@ -3569,7 +3608,6 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.10.0.tgz",
       "integrity": "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -3582,7 +3620,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
       "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -3606,7 +3643,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3623,14 +3659,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3643,7 +3677,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3656,14 +3689,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.19.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
       "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3673,7 +3704,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
       "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3683,7 +3713,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.5.tgz",
       "integrity": "sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.10.0",
@@ -3697,7 +3726,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -3707,7 +3735,6 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -3721,7 +3748,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -3735,7 +3761,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -3749,7 +3774,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
       "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -3993,7 +4017,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -4007,7 +4030,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4017,7 +4039,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -5050,7 +5071,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -5120,7 +5140,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/mime": {
@@ -5565,7 +5584,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.21.0.tgz",
       "integrity": "sha512-G3IBKz0/0IPfdeGRMbp+4rbjfSSdnGkXsM/pFZA8zM9t9klXDnB/YnKOBQ0GoPmoROa4bCq2NeHgJa5ydsQ4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.21.0",
@@ -5760,7 +5778,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.21.0.tgz",
       "integrity": "sha512-PAL6LUuQwotLW2a8VsySDBwYMm129vFm4tMVlylzdoTybTHaAi0oBp7Ac6LhSrHHOdLM3efH+nAR6hAWoMF89A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5774,7 +5791,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.21.0.tgz",
       "integrity": "sha512-x+aeKh/AjAArSauz0GiQZsjT8ciadNMHdkUSwBB9Z6PrKc/4knM4g3UfHml6oDJmKC88a6//cdxnO/+P2LkMcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.21.0",
@@ -5801,7 +5817,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5811,7 +5826,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -5827,7 +5841,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.21.0.tgz",
       "integrity": "sha512-xcXBfcq0Kaxgj7dwejMbFyq7IOHgpNMtVuDveK7w3ZGwG9owKzhALVwKpTF2yrZmEwl9SWdetf3fxNzJQaVuxw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -5851,7 +5864,6 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.21.0.tgz",
       "integrity": "sha512-BkLMNpdV6prozk8LlyK/SOoWLmUFi+ZD+pcqti9ILCbVvHGk1ui1g4jJOc2WDLaeExz2qWwojxlPce5PljcT3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.21.0",
@@ -5869,7 +5881,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6101,7 +6112,6 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6124,7 +6134,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -6692,7 +6701,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -6832,7 +6840,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6843,7 +6850,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -7060,7 +7066,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7404,7 +7409,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/connect": {
@@ -7726,7 +7730,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7741,7 +7744,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7853,7 +7855,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
       "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
@@ -7871,7 +7872,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/default-gateway": {
@@ -8386,7 +8386,6 @@
       "version": "9.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
       "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
@@ -8460,7 +8459,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -8473,7 +8471,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -8490,7 +8487,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -8506,7 +8502,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -8523,7 +8518,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -8536,14 +8530,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8556,7 +8548,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
       "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -8573,7 +8564,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8586,7 +8576,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8596,7 +8585,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -8613,7 +8601,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -8626,7 +8613,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8636,14 +8622,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -8659,7 +8643,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -8675,7 +8658,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -8691,7 +8673,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8704,7 +8685,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8717,7 +8697,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -8735,7 +8714,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8762,7 +8740,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -8775,7 +8752,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8785,7 +8761,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -8798,7 +8773,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -8818,7 +8792,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -9027,7 +9000,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -9044,14 +9016,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -9074,7 +9044,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -9113,7 +9082,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -9126,7 +9094,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -9229,7 +9196,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -9243,7 +9209,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -9517,7 +9482,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -9933,7 +9897,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -10003,7 +9966,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -10020,7 +9982,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10030,7 +9991,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -10202,7 +10162,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10222,7 +10181,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -10252,7 +10210,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -10354,7 +10311,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -10549,7 +10505,7 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -10600,7 +10556,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -10623,7 +10578,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -10897,7 +10851,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -11037,7 +10990,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -11123,7 +11075,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -11363,7 +11314,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -11383,7 +11333,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -11397,7 +11346,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -11495,7 +11443,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -11746,7 +11693,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -11796,7 +11742,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/needle": {
@@ -12299,7 +12244,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -12546,7 +12490,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -12646,7 +12589,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12666,7 +12608,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13008,7 +12949,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -13137,7 +13077,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13524,7 +13463,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -13608,7 +13546,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13777,7 +13714,6 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -13793,7 +13729,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -13806,7 +13741,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/send": {
@@ -14035,7 +13969,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14048,7 +13981,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14842,7 +14774,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -14907,7 +14838,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -14954,7 +14884,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15306,7 +15235,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -15316,7 +15244,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -16240,7 +16167,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finalshelf",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finalshelf",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "finalshelf",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "finalshelf"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "diesel",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -970,6 +970,7 @@ dependencies = [
  "diesel_migrations",
  "dotenv",
  "lofty",
+ "regex-lite",
  "rusqlite",
  "serde",
  "serde_json",
@@ -3058,6 +3059,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "finalshelf"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "diesel",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "finalshelf"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "diesel",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-dialog = "2"
 chrono = { version = "0.4.39", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
+regex-lite = "0.1"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finalshelf"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finalshelf"
-version = "0.4.8"
+version = "0.5.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "finalshelf"
-version = "0.5.1"
+version = "0.5.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/migrations/2026-03-06-100000_add_series/down.sql
+++ b/src-tauri/migrations/2026-03-06-100000_add_series/down.sql
@@ -1,0 +1,6 @@
+-- Remove series columns from books
+ALTER TABLE books DROP COLUMN series_id;
+ALTER TABLE books DROP COLUMN series_order;
+
+-- Drop series table
+DROP TABLE IF EXISTS series;

--- a/src-tauri/migrations/2026-03-06-100000_add_series/up.sql
+++ b/src-tauri/migrations/2026-03-06-100000_add_series/up.sql
@@ -1,0 +1,12 @@
+-- Create series table
+CREATE TABLE series (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    author_name VARCHAR(255) NOT NULL REFERENCES authors(name) ON DELETE CASCADE,
+    description TEXT,
+    UNIQUE(name, author_name)
+);
+
+-- Add series_id and series_order columns to books
+ALTER TABLE books ADD COLUMN series_id INTEGER REFERENCES series(id) ON DELETE SET NULL;
+ALTER TABLE books ADD COLUMN series_order INTEGER;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod dashboard_commands;
 pub(crate) mod genres_commands;
 pub(crate) mod lectors_commands;
 pub(crate) mod search_commands;
+pub(crate) mod series_commands;
 pub(crate) mod settings_commands;

--- a/src-tauri/src/commands/series_commands.rs
+++ b/src-tauri/src/commands/series_commands.rs
@@ -1,0 +1,48 @@
+use crate::{
+    models::{
+        series::{NewSeries, Series, SeriesListItem, SeriesWithBooks},
+        query::{ListParams, ListResponse},
+    },
+    services::series_service,
+};
+
+#[tauri::command]
+pub async fn get_series_list_command(params: ListParams) -> Result<ListResponse<SeriesListItem>, String> {
+    params.validate()?;
+    series_service::list_series(&params)
+}
+
+#[tauri::command]
+pub async fn get_series_command(id: i32) -> Result<SeriesWithBooks, String> {
+    series_service::get_series(id)
+}
+
+#[tauri::command]
+pub async fn create_series_command(name: String, author_name: String, description: Option<String>) -> Result<Series, String> {
+    let new_series = NewSeries {
+        name,
+        author_name,
+        description,
+    };
+    series_service::create_series(new_series)
+}
+
+#[tauri::command]
+pub async fn update_series_command(id: i32, name: Option<String>, description: Option<String>) -> Result<Series, String> {
+    series_service::update_series(id, name, description)
+}
+
+#[tauri::command]
+pub async fn delete_series_command(id: i32) -> Result<(), String> {
+    series_service::delete_series(id)
+}
+
+#[tauri::command]
+pub async fn assign_book_to_series_command(book_title: String, series_id: Option<i32>, series_order: Option<i32>) -> Result<(), String> {
+    series_service::assign_book_to_series(&book_title, series_id, series_order)
+}
+
+#[tauri::command]
+pub async fn get_series_by_author_command(author_name: String) -> Result<Vec<Series>, String> {
+    series_service::get_series_by_author(&author_name)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ mod services;
 
 use commands::{
     authors_commands::*, books_commands::*, dashboard_commands::*, genres_commands::*, lectors_commands::*,
-    search_commands::*, settings_commands::*,
+    search_commands::*, series_commands::*, settings_commands::*,
 };
 
 fn main() {
@@ -49,6 +49,14 @@ fn main() {
             // --- genres ---
             get_genres_list_command,
             get_genre_command,
+            // --- series ---
+            get_series_list_command,
+            get_series_command,
+            create_series_command,
+            update_series_command,
+            delete_series_command,
+            assign_book_to_series_command,
+            get_series_by_author_command,
             // --- dashboard ---
             get_dashboard_data_command,
         ])

--- a/src-tauri/src/models/book.rs
+++ b/src-tauri/src/models/book.rs
@@ -18,4 +18,6 @@ pub struct Book {
     pub score: Option<i32>,
     pub relative_file_path: String,
     pub duration_seconds: Option<i32>,
+    pub series_id: Option<i32>,
+    pub series_order: Option<i32>,
 }

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod genre;
 pub(crate) mod lector;
 pub(crate) mod path;
 pub(crate) mod query;
+pub(crate) mod series;
 pub(crate) mod tag;

--- a/src-tauri/src/models/series.rs
+++ b/src-tauri/src/models/series.rs
@@ -1,0 +1,39 @@
+use crate::schema::*;
+
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use super::book::Book;
+
+#[derive(Queryable, Selectable, Serialize, Deserialize, Debug)]
+#[diesel(table_name = series)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub struct Series {
+    pub id: i32,
+    pub name: String,
+    pub author_name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Insertable, Serialize, Deserialize, Debug)]
+#[diesel(table_name = series)]
+pub struct NewSeries {
+    pub name: String,
+    pub author_name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SeriesWithBooks {
+    pub series: Series,
+    pub books: Vec<Book>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SeriesListItem {
+    pub id: i32,
+    pub name: String,
+    pub author_name: String,
+    pub description: Option<String>,
+    pub books_count: i64,
+}

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -17,7 +17,7 @@ use crate::{
         absolute_paths_service::get_current_absolute_path,
         authors_service::{add_author, is_author_exists},
         books_service::{add_book, get_all_book_paths, is_book_exists},
-        series_service::{create_series, get_series_by_author, assign_book_to_series},
+        series_service::{create_series, get_series_by_author},
     },
 };
 
@@ -160,10 +160,12 @@ struct BookCandidate {
     detected_series_order: Option<i32>,
 }
 
-/// Detected series information from title or directory sructure.
+/// Detected series information from title or directory structure.
+#[allow(dead_code)]
 struct SeriesDetection {
     series_name: String,
     series_order: Option<i32>,
+    /// The cleaned title with series prefix removed. Reserved for future use.
     cleaned_title: String,
 }
 
@@ -594,15 +596,7 @@ where
 
         println!("Adding book: {:?}", book);
         match add_book(&book) {
-            Ok(_) => {
-                added += 1;
-                // If series was detected but not set during book creation, assign it now
-                if series_id.is_some() {
-                    if let Err(e) = assign_book_to_series(&candidate.title, series_id, candidate.detected_series_order) {
-                        eprintln!("Failed to assign book to series: {}", e);
-                    }
-                }
-            }
+            Ok(_) => added += 1,
             Err(e) => errors.push(format!("Failed to insert {}: {}", candidate.title, e)),
         }
     }

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -1,8 +1,9 @@
 use std::{
-    collections::HashSet,
-    fs,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
+    sync::LazyLock,
     time::Instant,
+    fs,
 };
 
 use chrono::{DateTime, NaiveDateTime, Utc};
@@ -28,6 +29,23 @@ use crate::{
 const AUDIO_EXTENSIONS: &[&str] = &["mp3", "m4b", "m4a", "ogg", "flac", "aac"];
 const COVER_NAMES: &[&str] = &["cover", "folder", "album", "poster", "default", "art"];
 const COVER_EXTENSIONS: &[&str] = &[".jpg", ".jpeg", ".png", ".gif", ".webp"];
+
+// Compiled once at first use — avoids repeated regex construction on hot scan paths.
+static SERIES_TITLE_PATTERN1: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
+    regex_lite::Regex::new(
+        r"^(.+?)\s*[-–—]\s*(?:(?:Part|Book|Vol\.?|Volume|Episode|Ep\.?|#)?\s*)?(\d+)\s*[-–—]\s*(.+)$",
+    )
+    .expect("Valid SERIES_TITLE_PATTERN1 regex")
+});
+
+static SERIES_TITLE_PATTERN2: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
+    regex_lite::Regex::new(r"^(.+?)\s+(\d+)\s*[-–—]\s*(.+)$")
+        .expect("Valid SERIES_TITLE_PATTERN2 regex")
+});
+
+static SERIES_DIR_ORDER: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
+    regex_lite::Regex::new(r"^(\d+)\s*[-–—]\s*(.+)$").expect("Valid SERIES_DIR_ORDER regex")
+});
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -162,11 +180,10 @@ struct BookCandidate {
 }
 
 /// Detected series information from title or directory structure.
-#[allow(dead_code)]
 struct SeriesDetection {
     series_name: String,
     series_order: Option<i32>,
-    /// The cleaned title with series prefix removed. Reserved for future use.
+    /// The cleaned title with series prefix removed.
     cleaned_title: String,
 }
 
@@ -296,11 +313,15 @@ fn extract_metadata(book_dir: &Path, base_path: &Path) -> Result<BookCandidate, 
     // Author photo
     let author_img_path = find_author_photo(book_dir, &author_name, base_path);
 
-    // Series detection
-    let (detected_series_name, detected_series_order) = detect_series(&title, book_dir, &author_name, base_path);
+    // Series detection: may also clean the title by removing series prefix
+    let detection = detect_series(&title, book_dir, &author_name, base_path);
+    let (clean_title, detected_series_name, detected_series_order) = match detection {
+        Some(d) => (d.cleaned_title, Some(d.series_name), d.series_order),
+        None => (title, None, None),
+    };
 
     Ok(BookCandidate {
-        title,
+        title: clean_title,
         author_name,
         genre,
         lector,
@@ -390,12 +411,7 @@ fn get_file_date(path: &Path) -> Option<NaiveDateTime> {
 /// - "Series Name Book 1 - Book Title"
 fn detect_series_from_title(title: &str) -> Option<SeriesDetection> {
     // Pattern 1: "Series - 01 - Title" or "Series - Part 1 - Title"
-    let pattern1 = regex_lite::Regex::new(
-        r"^(.+?)\s*[-–—]\s*(?:(?:Part|Book|Vol\.?|Volume|Episode|Ep\.?|#)?\s*)?(\d+)\s*[-–—]\s*(.+)$",
-    )
-    .ok()?;
-
-    if let Some(caps) = pattern1.captures(title) {
+    if let Some(caps) = SERIES_TITLE_PATTERN1.captures(title) {
         let series_name = caps.get(1)?.as_str().trim().to_string();
         let order: i32 = caps.get(2)?.as_str().parse().ok()?;
         let book_title = caps.get(3)?.as_str().trim().to_string();
@@ -411,9 +427,7 @@ fn detect_series_from_title(title: &str) -> Option<SeriesDetection> {
     }
 
     // Pattern 2: "Series 01 - Title" (number directly after series name)
-    let pattern2 = regex_lite::Regex::new(r"^(.+?)\s+(\d+)\s*[-–—]\s*(.+)$").ok()?;
-
-    if let Some(caps) = pattern2.captures(title) {
+    if let Some(caps) = SERIES_TITLE_PATTERN2.captures(title) {
         let series_name = caps.get(1)?.as_str().trim().to_string();
         let order: i32 = caps.get(2)?.as_str().parse().ok()?;
         let book_title = caps.get(3)?.as_str().trim().to_string();
@@ -459,8 +473,7 @@ fn detect_series_from_directory(book_dir: &Path, author_name: &str, base_path: &
                 .chars()
                 .all(|c| c.is_numeric() || c.is_whitespace() || c == '-')
         {
-            let order_regex = regex_lite::Regex::new(r"^(\d+)\s*[-–—]\s*(.+)$").ok()?;
-            let series_order = order_regex
+            let series_order = SERIES_DIR_ORDER
                 .captures(book_dir_name)
                 .and_then(|caps| caps.get(1))
                 .and_then(|m| m.as_str().parse::<i32>().ok());
@@ -474,18 +487,25 @@ fn detect_series_from_directory(book_dir: &Path, author_name: &str, base_path: &
 
 /// Combine series detection from title and directory structure.
 /// Title detection takes priority as it often includes order information.
-fn detect_series(title: &str, book_dir: &Path, author_name: &str, base_path: &Path) -> (Option<String>, Option<i32>) {
-    // First try title-based detection (includes order)
+/// Returns `Some(SeriesDetection)` when a series is detected, with `cleaned_title`
+/// holding the book title with any series prefix stripped. Returns `None` when
+/// no series is detected and the original title should be used.
+fn detect_series(title: &str, book_dir: &Path, author_name: &str, base_path: &Path) -> Option<SeriesDetection> {
+    // First try title-based detection (includes order and cleaned title)
     if let Some(detection) = detect_series_from_title(title) {
-        return (Some(detection.series_name), detection.series_order);
+        return Some(detection);
     }
 
-    // Fall back to directory-based detection (no order info)
+    // Fall back to directory-based detection (no order info, title unchanged)
     if let Some((series_name, series_order)) = detect_series_from_directory(book_dir, author_name, base_path) {
-        return (Some(series_name), series_order);
+        return Some(SeriesDetection {
+            series_name,
+            series_order,
+            cleaned_title: title.to_string(),
+        });
     }
 
-    (None, None)
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -496,15 +516,16 @@ fn persist_batch_with_progress<F>(candidates: Vec<BookCandidate>, on_progress: &
 where
     F: FnMut(ScanProgress),
 {
-    use std::collections::HashMap;
-
     let mut added: i64 = 0;
     let mut skipped: i64 = 0;
     let mut errors: Vec<String> = Vec::new();
     let total = candidates.len() as i64;
 
-    // Cache for series IDs: (author_name, series_name) -> series_id
+    // Cache for series IDs: (author_name, series_name_lowercase) -> series_id
+    // A value of -1 means series creation previously failed (skip retry).
     let mut series_cache: HashMap<(String, String), i32> = HashMap::new();
+    // Tracks authors whose full series list has been loaded into the cache.
+    let mut authors_loaded: HashSet<String> = HashSet::new();
 
     for (idx, candidate) in candidates.into_iter().enumerate() {
         on_progress(ScanProgress {
@@ -536,20 +557,34 @@ where
 
         // Handle series detection
         let series_id = if let Some(ref series_name) = candidate.detected_series_name {
-            let cache_key = (candidate.author_name.clone(), series_name.clone());
+            let series_key = series_name.to_lowercase();
+            let cache_key = (candidate.author_name.clone(), series_key.clone());
 
             if let Some(&cached_id) = series_cache.get(&cache_key) {
-                Some(cached_id)
+                // Positive: known series id; negative: known failure, skip
+                if cached_id > 0 { Some(cached_id) } else { None }
             } else {
-                // Check if series already exists for this author
-                let existing_series_id = get_series_by_author(&candidate.author_name)
-                    .ok()
-                    .and_then(|series_list| {
-                        series_list
-                            .iter()
-                            .find(|s| s.name.to_lowercase() == series_name.to_lowercase())
-                            .map(|s| s.id)
-                    });
+                // Determine if series already exists for this author.
+                // Load all of the author's series on first encounter to populate
+                // the cache and avoid per-book DB queries.
+                let existing_series_id = if authors_loaded.contains(&candidate.author_name) {
+                    // Already loaded this author's series — not in cache means doesn't exist yet
+                    None
+                } else {
+                    authors_loaded.insert(candidate.author_name.clone());
+                    get_series_by_author(&candidate.author_name)
+                        .ok()
+                        .and_then(|series_list| {
+                            for s in &series_list {
+                                let key = (candidate.author_name.clone(), s.name.to_lowercase());
+                                series_cache.entry(key).or_insert(s.id);
+                            }
+                            series_list
+                                .iter()
+                                .find(|s| s.name.to_lowercase() == series_key)
+                                .map(|s| s.id)
+                        })
+                };
 
                 let id = if let Some(existing_id) = existing_series_id {
                     existing_id
@@ -566,18 +601,14 @@ where
                         },
                         Err(e) => {
                             eprintln!("Failed to create series '{}': {}", series_name, e);
-                            // Continue without series assignment
-                            -1
+                            -1  // failure sentinel
                         },
                     }
                 };
 
-                if id > 0 {
-                    series_cache.insert(cache_key, id);
-                    Some(id)
-                } else {
-                    None
-                }
+                // Always cache the result so we never retry the same DB operation
+                series_cache.insert(cache_key, id);
+                if id > 0 { Some(id) } else { None }
             }
         } else {
             None

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -63,11 +63,7 @@ where
     let directory = absolute_path_obj.absolute_path;
     let base_path = Path::new(&directory);
 
-    println!(
-        "Starting {} scan in {}",
-        if full { "full" } else { "quick" },
-        directory
-    );
+    println!("Starting {} scan in {}", if full { "full" } else { "quick" }, directory);
     let start = Instant::now();
 
     // -- Phase 1: Discovery ---------------------------------------------------
@@ -98,14 +94,17 @@ where
             phase: "extraction".to_string(),
             current: idx as i64 + 1,
             total: total_dirs,
-            message: format!("Extracting metadata from: {}", dir.file_name().unwrap_or_default().to_string_lossy()),
+            message: format!(
+                "Extracting metadata from: {}",
+                dir.file_name().unwrap_or_default().to_string_lossy()
+            ),
         });
 
         match extract_metadata(dir, base_path) {
             Ok(candidate) => candidates.push(candidate),
             Err(e) => {
                 eprintln!("Skipping {:?}: {}", dir, e);
-            }
+            },
         }
     }
     println!("Extracted metadata for {} books", candidates.len());
@@ -126,7 +125,9 @@ where
         total: result.added + result.skipped,
         message: format!(
             "Scan complete: {} added, {} skipped, {} errors",
-            result.added, result.skipped, result.errors.len()
+            result.added,
+            result.skipped,
+            result.errors.len()
         ),
     });
 
@@ -190,7 +191,7 @@ fn build_skip_set(full: bool, base_path: &Path) -> HashSet<String> {
         Err(e) => {
             eprintln!("Could not load known dirs from DB: {}. Starting fresh.", e);
             HashSet::new()
-        }
+        },
     }
 }
 
@@ -199,11 +200,7 @@ fn build_skip_set(full: bool, base_path: &Path) -> HashSet<String> {
 fn discover_book_dirs(root: &Path, skip: &HashSet<String>) -> Vec<PathBuf> {
     let mut book_dirs: HashSet<PathBuf> = HashSet::new();
 
-    for entry in WalkDir::new(root)
-        .min_depth(1)
-        .into_iter()
-        .filter_map(Result::ok)
-    {
+    for entry in WalkDir::new(root).min_depth(1).into_iter().filter_map(Result::ok) {
         let path = entry.path();
         if is_audio_file(path) {
             if let Some(parent) = path.parent() {
@@ -372,7 +369,7 @@ fn get_file_date(path: &Path) -> Option<NaiveDateTime> {
             } else {
                 m
             }
-        }
+        },
         (Some(c), None) => c,
         (None, Some(m)) => m,
         (None, None) => return None,
@@ -394,14 +391,15 @@ fn get_file_date(path: &Path) -> Option<NaiveDateTime> {
 fn detect_series_from_title(title: &str) -> Option<SeriesDetection> {
     // Pattern 1: "Series - 01 - Title" or "Series - Part 1 - Title"
     let pattern1 = regex_lite::Regex::new(
-        r"^(.+?)\s*[-–—]\s*(?:(?:Part|Book|Vol\.?|Volume|Episode|Ep\.?|#)?\s*)?(\d+)\s*[-–—]\s*(.+)$"
-    ).ok()?;
-    
+        r"^(.+?)\s*[-–—]\s*(?:(?:Part|Book|Vol\.?|Volume|Episode|Ep\.?|#)?\s*)?(\d+)\s*[-–—]\s*(.+)$",
+    )
+    .ok()?;
+
     if let Some(caps) = pattern1.captures(title) {
         let series_name = caps.get(1)?.as_str().trim().to_string();
         let order: i32 = caps.get(2)?.as_str().parse().ok()?;
         let book_title = caps.get(3)?.as_str().trim().to_string();
-        
+
         // Validate series name is reasonable (not just numbers or too short)
         if series_name.len() >= 2 && !series_name.chars().all(|c| c.is_numeric() || c.is_whitespace()) {
             return Some(SeriesDetection {
@@ -411,17 +409,15 @@ fn detect_series_from_title(title: &str) -> Option<SeriesDetection> {
             });
         }
     }
-    
+
     // Pattern 2: "Series 01 - Title" (number directly after series name)
-    let pattern2 = regex_lite::Regex::new(
-        r"^(.+?)\s+(\d+)\s*[-–—]\s*(.+)$"
-    ).ok()?;
-    
+    let pattern2 = regex_lite::Regex::new(r"^(.+?)\s+(\d+)\s*[-–—]\s*(.+)$").ok()?;
+
     if let Some(caps) = pattern2.captures(title) {
         let series_name = caps.get(1)?.as_str().trim().to_string();
         let order: i32 = caps.get(2)?.as_str().parse().ok()?;
         let book_title = caps.get(3)?.as_str().trim().to_string();
-        
+
         if series_name.len() >= 2 && !series_name.chars().all(|c| c.is_numeric() || c.is_whitespace()) {
             return Some(SeriesDetection {
                 series_name,
@@ -430,42 +426,49 @@ fn detect_series_from_title(title: &str) -> Option<SeriesDetection> {
             });
         }
     }
-    
+
     None
 }
 
 /// Try to detect series from directory structure.
 /// Looks for pattern: .../Author/Series/Book or .../Author/Series/NN - Book
-fn detect_series_from_directory(book_dir: &Path, author_name: &str, base_path: &Path) -> Option<String> {
+fn detect_series_from_directory(book_dir: &Path, author_name: &str, base_path: &Path) -> Option<(String, Option<i32>)> {
     // Get the relative path from base
     let rel_path = book_dir.strip_prefix(base_path).ok()?;
-    let components: Vec<&str> = rel_path
-        .components()
-        .filter_map(|c| c.as_os_str().to_str())
-        .collect();
-    
+    let components: Vec<&str> = rel_path.components().filter_map(|c| c.as_os_str().to_str()).collect();
+
     // We need at least 3 levels: Author/Series/Book
     if components.len() < 3 {
         return None;
     }
-    
+
     // Find the author directory in the path
-    let author_index = components.iter()
+    let author_index = components
+        .iter()
         .position(|&c| c.to_lowercase() == author_name.to_lowercase())?;
-    
+
     // The next component after author should be the series
     // (if there's still a book directory after that)
     if author_index + 2 < components.len() {
         let series_name = components[author_index + 1].to_string();
-        
+        let book_dir_name = components[author_index + 2];
+
         // Validate series name: not just numbers, reasonable length
-        if series_name.len() >= 2 
-            && !series_name.chars().all(|c| c.is_numeric() || c.is_whitespace() || c == '-') 
+        if series_name.len() >= 2
+            && !series_name
+                .chars()
+                .all(|c| c.is_numeric() || c.is_whitespace() || c == '-')
         {
-            return Some(series_name);
+            let order_regex = regex_lite::Regex::new(r"^(\d+)\s*[-–—]\s*(.+)$").ok()?;
+            let series_order = order_regex
+                .captures(book_dir_name)
+                .and_then(|caps| caps.get(1))
+                .and_then(|m| m.as_str().parse::<i32>().ok());
+
+            return Some((series_name, series_order));
         }
     }
-    
+
     None
 }
 
@@ -476,12 +479,12 @@ fn detect_series(title: &str, book_dir: &Path, author_name: &str, base_path: &Pa
     if let Some(detection) = detect_series_from_title(title) {
         return (Some(detection.series_name), detection.series_order);
     }
-    
+
     // Fall back to directory-based detection (no order info)
-    if let Some(series_name) = detect_series_from_directory(book_dir, author_name, base_path) {
-        return (Some(series_name), None);
+    if let Some((series_name, series_order)) = detect_series_from_directory(book_dir, author_name, base_path) {
+        return (Some(series_name), series_order);
     }
-    
+
     (None, None)
 }
 
@@ -494,12 +497,12 @@ where
     F: FnMut(ScanProgress),
 {
     use std::collections::HashMap;
-    
+
     let mut added: i64 = 0;
     let mut skipped: i64 = 0;
     let mut errors: Vec<String> = Vec::new();
     let total = candidates.len() as i64;
-    
+
     // Cache for series IDs: (author_name, series_name) -> series_id
     let mut series_cache: HashMap<(String, String), i32> = HashMap::new();
 
@@ -534,7 +537,7 @@ where
         // Handle series detection
         let series_id = if let Some(ref series_name) = candidate.detected_series_name {
             let cache_key = (candidate.author_name.clone(), series_name.clone());
-            
+
             if let Some(&cached_id) = series_cache.get(&cache_key) {
                 Some(cached_id)
             } else {
@@ -542,11 +545,12 @@ where
                 let existing_series_id = get_series_by_author(&candidate.author_name)
                     .ok()
                     .and_then(|series_list| {
-                        series_list.iter()
+                        series_list
+                            .iter()
                             .find(|s| s.name.to_lowercase() == series_name.to_lowercase())
                             .map(|s| s.id)
                     });
-                
+
                 let id = if let Some(existing_id) = existing_series_id {
                     existing_id
                 } else {
@@ -559,15 +563,15 @@ where
                         Ok(new_series) => {
                             println!("Created series: {} (id: {})", series_name, new_series.id);
                             new_series.id
-                        }
+                        },
                         Err(e) => {
                             eprintln!("Failed to create series '{}': {}", series_name, e);
                             // Continue without series assignment
                             -1
-                        }
+                        },
                     }
                 };
-                
+
                 if id > 0 {
                     series_cache.insert(cache_key, id);
                     Some(id)
@@ -601,9 +605,5 @@ where
         }
     }
 
-    ScanResult {
-        added,
-        skipped,
-        errors,
-    }
+    ScanResult { added, skipped, errors }
 }

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -12,11 +12,12 @@ use lofty::tag::ItemKey;
 use walkdir::WalkDir;
 
 use crate::{
-    models::{author::Author, book::Book},
+    models::{author::Author, book::Book, series::NewSeries},
     services::{
         absolute_paths_service::get_current_absolute_path,
         authors_service::{add_author, is_author_exists},
         books_service::{add_book, get_all_book_paths, is_book_exists},
+        series_service::{create_series, get_series_by_author, assign_book_to_series},
     },
 };
 
@@ -154,6 +155,16 @@ struct BookCandidate {
     relative_cover_path: Option<String>,
     relative_file_path: String,
     author_img_path: Option<String>,
+    // Series detection fields
+    detected_series_name: Option<String>,
+    detected_series_order: Option<i32>,
+}
+
+/// Detected series information from title or directory sructure.
+struct SeriesDetection {
+    series_name: String,
+    series_order: Option<i32>,
+    cleaned_title: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -286,6 +297,9 @@ fn extract_metadata(book_dir: &Path, base_path: &Path) -> Result<BookCandidate, 
     // Author photo
     let author_img_path = find_author_photo(book_dir, &author_name, base_path);
 
+    // Series detection
+    let (detected_series_name, detected_series_order) = detect_series(&title, book_dir, &author_name, base_path);
+
     Ok(BookCandidate {
         title,
         author_name,
@@ -296,6 +310,8 @@ fn extract_metadata(book_dir: &Path, base_path: &Path) -> Result<BookCandidate, 
         relative_cover_path,
         relative_file_path,
         author_img_path,
+        detected_series_name,
+        detected_series_order,
     })
 }
 
@@ -364,6 +380,110 @@ fn get_file_date(path: &Path) -> Option<NaiveDateTime> {
 }
 
 // ---------------------------------------------------------------------------
+// Series Detection
+// ---------------------------------------------------------------------------
+
+/// Try to detect series from title patterns.
+/// Supports patterns like:
+/// - "Series Name - 01 - Book Title"
+/// - "Series Name 01 - Book Title"
+/// - "Series Name - Part 1 - Book Title"
+/// - "Series Name Book 1 - Book Title"
+fn detect_series_from_title(title: &str) -> Option<SeriesDetection> {
+    // Pattern 1: "Series - 01 - Title" or "Series - Part 1 - Title"
+    let pattern1 = regex_lite::Regex::new(
+        r"^(.+?)\s*[-–—]\s*(?:(?:Part|Book|Vol\.?|Volume|Episode|Ep\.?|#)?\s*)?(\d+)\s*[-–—]\s*(.+)$"
+    ).ok()?;
+    
+    if let Some(caps) = pattern1.captures(title) {
+        let series_name = caps.get(1)?.as_str().trim().to_string();
+        let order: i32 = caps.get(2)?.as_str().parse().ok()?;
+        let book_title = caps.get(3)?.as_str().trim().to_string();
+        
+        // Validate series name is reasonable (not just numbers or too short)
+        if series_name.len() >= 2 && !series_name.chars().all(|c| c.is_numeric() || c.is_whitespace()) {
+            return Some(SeriesDetection {
+                series_name,
+                series_order: Some(order),
+                cleaned_title: book_title,
+            });
+        }
+    }
+    
+    // Pattern 2: "Series 01 - Title" (number directly after series name)
+    let pattern2 = regex_lite::Regex::new(
+        r"^(.+?)\s+(\d+)\s*[-–—]\s*(.+)$"
+    ).ok()?;
+    
+    if let Some(caps) = pattern2.captures(title) {
+        let series_name = caps.get(1)?.as_str().trim().to_string();
+        let order: i32 = caps.get(2)?.as_str().parse().ok()?;
+        let book_title = caps.get(3)?.as_str().trim().to_string();
+        
+        if series_name.len() >= 2 && !series_name.chars().all(|c| c.is_numeric() || c.is_whitespace()) {
+            return Some(SeriesDetection {
+                series_name,
+                series_order: Some(order),
+                cleaned_title: book_title,
+            });
+        }
+    }
+    
+    None
+}
+
+/// Try to detect series from directory structure.
+/// Looks for pattern: .../Author/Series/Book or .../Author/Series/NN - Book
+fn detect_series_from_directory(book_dir: &Path, author_name: &str, base_path: &Path) -> Option<String> {
+    // Get the relative path from base
+    let rel_path = book_dir.strip_prefix(base_path).ok()?;
+    let components: Vec<&str> = rel_path
+        .components()
+        .filter_map(|c| c.as_os_str().to_str())
+        .collect();
+    
+    // We need at least 3 levels: Author/Series/Book
+    if components.len() < 3 {
+        return None;
+    }
+    
+    // Find the author directory in the path
+    let author_index = components.iter()
+        .position(|&c| c.to_lowercase() == author_name.to_lowercase())?;
+    
+    // The next component after author should be the series
+    // (if there's still a book directory after that)
+    if author_index + 2 < components.len() {
+        let series_name = components[author_index + 1].to_string();
+        
+        // Validate series name: not just numbers, reasonable length
+        if series_name.len() >= 2 
+            && !series_name.chars().all(|c| c.is_numeric() || c.is_whitespace() || c == '-') 
+        {
+            return Some(series_name);
+        }
+    }
+    
+    None
+}
+
+/// Combine series detection from title and directory structure.
+/// Title detection takes priority as it often includes order information.
+fn detect_series(title: &str, book_dir: &Path, author_name: &str, base_path: &Path) -> (Option<String>, Option<i32>) {
+    // First try title-based detection (includes order)
+    if let Some(detection) = detect_series_from_title(title) {
+        return (Some(detection.series_name), detection.series_order);
+    }
+    
+    // Fall back to directory-based detection (no order info)
+    if let Some(series_name) = detect_series_from_directory(book_dir, author_name, base_path) {
+        return (Some(series_name), None);
+    }
+    
+    (None, None)
+}
+
+// ---------------------------------------------------------------------------
 // Phase 3 – Persist
 // ---------------------------------------------------------------------------
 
@@ -371,10 +491,15 @@ fn persist_batch_with_progress<F>(candidates: Vec<BookCandidate>, on_progress: &
 where
     F: FnMut(ScanProgress),
 {
+    use std::collections::HashMap;
+    
     let mut added: i64 = 0;
     let mut skipped: i64 = 0;
     let mut errors: Vec<String> = Vec::new();
     let total = candidates.len() as i64;
+    
+    // Cache for series IDs: (author_name, series_name) -> series_id
+    let mut series_cache: HashMap<(String, String), i32> = HashMap::new();
 
     for (idx, candidate) in candidates.into_iter().enumerate() {
         on_progress(ScanProgress {
@@ -404,6 +529,54 @@ where
             }
         }
 
+        // Handle series detection
+        let series_id = if let Some(ref series_name) = candidate.detected_series_name {
+            let cache_key = (candidate.author_name.clone(), series_name.clone());
+            
+            if let Some(&cached_id) = series_cache.get(&cache_key) {
+                Some(cached_id)
+            } else {
+                // Check if series already exists for this author
+                let existing_series_id = get_series_by_author(&candidate.author_name)
+                    .ok()
+                    .and_then(|series_list| {
+                        series_list.iter()
+                            .find(|s| s.name.to_lowercase() == series_name.to_lowercase())
+                            .map(|s| s.id)
+                    });
+                
+                let id = if let Some(existing_id) = existing_series_id {
+                    existing_id
+                } else {
+                    // Create new series
+                    match create_series(NewSeries {
+                        name: series_name.clone(),
+                        author_name: candidate.author_name.clone(),
+                        description: None,
+                    }) {
+                        Ok(new_series) => {
+                            println!("Created series: {} (id: {})", series_name, new_series.id);
+                            new_series.id
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to create series '{}': {}", series_name, e);
+                            // Continue without series assignment
+                            -1
+                        }
+                    }
+                };
+                
+                if id > 0 {
+                    series_cache.insert(cache_key, id);
+                    Some(id)
+                } else {
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
         let book = Book {
             title: candidate.title.clone(),
             author_name: candidate.author_name,
@@ -415,13 +588,21 @@ where
             score: Some(0),
             relative_file_path: candidate.relative_file_path,
             duration_seconds: Some(candidate.duration_seconds),
-            series_id: None,
-            series_order: None,
+            series_id,
+            series_order: candidate.detected_series_order,
         };
 
         println!("Adding book: {:?}", book);
         match add_book(&book) {
-            Ok(_) => added += 1,
+            Ok(_) => {
+                added += 1;
+                // If series was detected but not set during book creation, assign it now
+                if series_id.is_some() {
+                    if let Err(e) = assign_book_to_series(&candidate.title, series_id, candidate.detected_series_order) {
+                        eprintln!("Failed to assign book to series: {}", e);
+                    }
+                }
+            }
             Err(e) => errors.push(format!("Failed to insert {}: {}", candidate.title, e)),
         }
     }

--- a/src-tauri/src/scanner.rs
+++ b/src-tauri/src/scanner.rs
@@ -415,6 +415,8 @@ where
             score: Some(0),
             relative_file_path: candidate.relative_file_path,
             duration_seconds: Some(candidate.duration_seconds),
+            series_id: None,
+            series_order: None,
         };
 
         println!("Adding book: {:?}", book);

--- a/src-tauri/src/schema.rs
+++ b/src-tauri/src/schema.rs
@@ -28,6 +28,17 @@ diesel::table! {
         score -> Nullable<Integer>,
         relative_file_path -> Text,
         duration_seconds -> Nullable<Integer>,
+        series_id -> Nullable<Integer>,
+        series_order -> Nullable<Integer>,
+    }
+}
+
+diesel::table! {
+    series (id) {
+        id -> Integer,
+        name -> Text,
+        author_name -> Text,
+        description -> Nullable<Text>,
     }
 }
 
@@ -46,7 +57,9 @@ diesel::table! {
 }
 
 diesel::joinable!(books -> authors (author_name));
+diesel::joinable!(books -> series (series_id));
+diesel::joinable!(series -> authors (author_name));
 diesel::joinable!(tags_books -> books (book_title));
 diesel::joinable!(tags_books -> tags (tag_id));
 
-diesel::allow_tables_to_appear_in_same_query!(absolute_paths, authors, books, tags, tags_books,);
+diesel::allow_tables_to_appear_in_same_query!(absolute_paths, authors, books, series, tags, tags_books,);

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod authors_service;
 pub(crate) mod books_service;
 pub(crate) mod genres_service;
 pub(crate) mod lectors_service;
+pub(crate) mod series_service;

--- a/src-tauri/src/services/series_service.rs
+++ b/src-tauri/src/services/series_service.rs
@@ -1,0 +1,198 @@
+use crate::{
+    db::establish_connection,
+    models::{
+        book::Book,
+        series::{NewSeries, Series, SeriesListItem, SeriesWithBooks},
+        query::{ListParams, ListResponse},
+    },
+    schema::{books, series},
+};
+use diesel::{dsl::count, prelude::*};
+
+/// List all series with pagination, sorting, filtering, and search.
+///
+/// ## Sort fields
+/// `"name"`, `"author_name"`, `"books_count"` (default: `"name"`)
+pub fn list_series(params: &ListParams) -> Result<ListResponse<SeriesListItem>, String> {
+    let conn = &mut establish_connection();
+
+    // Load all series with book counts via LEFT JOIN + GROUP BY.
+    let mut items: Vec<SeriesListItem> = series::table
+        .left_join(books::table.on(series::id.nullable().eq(books::series_id)))
+        .group_by(series::id)
+        .select((
+            series::id,
+            series::name,
+            series::author_name,
+            series::description,
+            count(books::title.nullable()),
+        ))
+        .load::<(i32, String, String, Option<String>, i64)>(conn)
+        .map_err(|e| format!("Failed to load series: {}", e))?
+        .into_iter()
+        .map(|(id, name, author_name, description, cnt)| SeriesListItem {
+            id,
+            name,
+            author_name,
+            description,
+            books_count: cnt,
+        })
+        .collect();
+
+    // Search filter (case-insensitive substring match on name or author_name)
+    if let Some(ref search) = params.search {
+        let lower = search.to_lowercase();
+        items.retain(|s| {
+            s.name.to_lowercase().contains(&lower)
+                || s.author_name.to_lowercase().contains(&lower)
+        });
+    }
+
+    // Author filter
+    if let Some(ref author) = params.author_name {
+        items.retain(|s| s.author_name == *author);
+    }
+
+    // Sort
+    let sort_by = params.sort_field(&["name", "author_name", "books_count"], "name");
+    let desc = params.is_desc();
+    match sort_by.as_str() {
+        "books_count" => items.sort_by(|a, b| {
+            let cmp = a.books_count.cmp(&b.books_count);
+            if desc { cmp.reverse() } else { cmp }
+        }),
+        "author_name" => items.sort_by(|a, b| {
+            let cmp = a.author_name.to_lowercase().cmp(&b.author_name.to_lowercase());
+            if desc { cmp.reverse() } else { cmp }
+        }),
+        _ => items.sort_by(|a, b| {
+            let cmp = a.name.to_lowercase().cmp(&b.name.to_lowercase());
+            if desc { cmp.reverse() } else { cmp }
+        }),
+    }
+
+    // Paginate
+    let total_count = items.len() as i64;
+    let limit = params.limit();
+    let offset = params.offset() as usize;
+    let page_items: Vec<SeriesListItem> = items
+        .into_iter()
+        .skip(offset)
+        .take(limit as usize)
+        .collect();
+
+    Ok(ListResponse::new(
+        page_items,
+        total_count,
+        params.page(),
+        limit,
+    ))
+}
+
+/// Get a single series by ID with its associated books (ordered by series_order).
+pub fn get_series(id: i32) -> Result<SeriesWithBooks, String> {
+    let conn = &mut establish_connection();
+
+    let series_record = series::table
+        .find(id)
+        .first::<Series>(conn)
+        .map_err(|e| format!("Series not found: {}", e))?;
+
+    let series_books = books::table
+        .filter(books::series_id.eq(id))
+        .order(books::series_order.asc())
+        .load::<Book>(conn)
+        .map_err(|e| format!("Failed to load series books: {}", e))?;
+
+    Ok(SeriesWithBooks {
+        series: series_record,
+        books: series_books,
+    })
+}
+
+/// Create a new series.
+pub fn create_series(new_series: NewSeries) -> Result<Series, String> {
+    let conn = &mut establish_connection();
+
+    diesel::insert_into(series::table)
+        .values(&new_series)
+        .execute(conn)
+        .map_err(|e| format!("Failed to create series: {}", e))?;
+
+    series::table
+        .filter(series::name.eq(&new_series.name))
+        .filter(series::author_name.eq(&new_series.author_name))
+        .first::<Series>(conn)
+        .map_err(|e| format!("Failed to retrieve created series: {}", e))
+}
+
+/// Update series details.
+pub fn update_series(id: i32, name: Option<String>, description: Option<String>) -> Result<Series, String> {
+    let conn = &mut establish_connection();
+
+    if let Some(ref new_name) = name {
+        diesel::update(series::table.find(id))
+            .set(series::name.eq(new_name))
+            .execute(conn)
+            .map_err(|e| format!("Failed to update series name: {}", e))?;
+    }
+
+    if let Some(ref new_desc) = description {
+        diesel::update(series::table.find(id))
+            .set(series::description.eq(new_desc))
+            .execute(conn)
+            .map_err(|e| format!("Failed to update series description: {}", e))?;
+    }
+
+    series::table
+        .find(id)
+        .first::<Series>(conn)
+        .map_err(|e| format!("Series not found: {}", e))
+}
+
+/// Delete a series (books will have their series_id set to NULL due to ON DELETE SET NULL).
+pub fn delete_series(id: i32) -> Result<(), String> {
+    let conn = &mut establish_connection();
+
+    diesel::delete(series::table.find(id))
+        .execute(conn)
+        .map_err(|e| format!("Failed to delete series: {}", e))?;
+
+    Ok(())
+}
+
+/// Assign a book to a series with a specific order.
+pub fn assign_book_to_series(book_title: &str, series_id: Option<i32>, series_order: Option<i32>) -> Result<(), String> {
+    let conn = &mut establish_connection();
+
+    diesel::update(books::table.find(book_title))
+        .set((
+            books::series_id.eq(series_id),
+            books::series_order.eq(series_order),
+        ))
+        .execute(conn)
+        .map_err(|e| format!("Failed to assign book to series: {}", e))?;
+
+    Ok(())
+}
+
+/// Get series count for dashboard.
+pub fn get_series_count() -> Result<i64, String> {
+    let conn = &mut establish_connection();
+
+    series::table
+        .count()
+        .get_result::<i64>(conn)
+        .map_err(|e| format!("Failed to count series: {}", e))
+}
+
+/// Get series by author.
+pub fn get_series_by_author(author_name: &str) -> Result<Vec<Series>, String> {
+    let conn = &mut establish_connection();
+
+    series::table
+        .filter(series::author_name.eq(author_name))
+        .order(series::name.asc())
+        .load::<Series>(conn)
+        .map_err(|e| format!("Failed to load series for author: {}", e))
+}

--- a/src-tauri/src/services/series_service.rs
+++ b/src-tauri/src/services/series_service.rs
@@ -11,13 +11,19 @@ use diesel::{dsl::count, prelude::*};
 
 /// List all series with pagination, sorting, filtering, and search.
 ///
+/// Filters (search, author) are applied at the SQL level to avoid loading
+/// the full table. Sort and pagination are applied in Rust because `books_count`
+/// is a computed aggregate column.
+///
 /// ## Sort fields
 /// `"name"`, `"author_name"`, `"books_count"` (default: `"name"`)
 pub fn list_series(params: &ListParams) -> Result<ListResponse<SeriesListItem>, String> {
     let conn = &mut establish_connection();
 
-    // Load all series with book counts via LEFT JOIN + GROUP BY.
-    let mut items: Vec<SeriesListItem> = series::table
+    let search_pattern = params.search_pattern();
+
+    // Build the joined query with optional SQL-level filters.
+    let mut query = series::table
         .left_join(books::table.on(series::id.nullable().eq(books::series_id)))
         .group_by(series::id)
         .select((
@@ -27,8 +33,27 @@ pub fn list_series(params: &ListParams) -> Result<ListResponse<SeriesListItem>, 
             series::description,
             count(books::title.nullable()),
         ))
+        .into_boxed();
+
+    if let Some(ref pattern) = search_pattern {
+        query = query.filter(
+            series::name
+                .like(pattern)
+                .or(series::author_name.like(pattern)),
+        );
+    }
+
+    if let Some(ref author) = params.author_name {
+        query = query.filter(series::author_name.eq(author.clone()));
+    }
+
+    let all_items: Vec<(i32, String, String, Option<String>, i64)> = query
         .load::<(i32, String, String, Option<String>, i64)>(conn)
-        .map_err(|e| format!("Failed to load series: {}", e))?
+        .map_err(|e| format!("Failed to load series: {}", e))?;
+
+    let total_count = all_items.len() as i64;
+
+    let mut items: Vec<SeriesListItem> = all_items
         .into_iter()
         .map(|(id, name, author_name, description, cnt)| SeriesListItem {
             id,
@@ -39,21 +64,7 @@ pub fn list_series(params: &ListParams) -> Result<ListResponse<SeriesListItem>, 
         })
         .collect();
 
-    // Search filter (case-insensitive substring match on name or author_name)
-    if let Some(ref search) = params.search {
-        let lower = search.to_lowercase();
-        items.retain(|s| {
-            s.name.to_lowercase().contains(&lower)
-                || s.author_name.to_lowercase().contains(&lower)
-        });
-    }
-
-    // Author filter
-    if let Some(ref author) = params.author_name {
-        items.retain(|s| s.author_name == *author);
-    }
-
-    // Sort
+    // Sort in Rust (needed for case-insensitive string sort and books_count)
     let sort_by = params.sort_field(&["name", "author_name", "books_count"], "name");
     let desc = params.is_desc();
     match sort_by.as_str() {
@@ -71,8 +82,7 @@ pub fn list_series(params: &ListParams) -> Result<ListResponse<SeriesListItem>, 
         }),
     }
 
-    // Paginate
-    let total_count = items.len() as i64;
+    // Paginate in Rust
     let limit = params.limit();
     let offset = params.offset() as usize;
     let page_items: Vec<SeriesListItem> = items
@@ -100,7 +110,11 @@ pub fn get_series(id: i32) -> Result<SeriesWithBooks, String> {
 
     let series_books = books::table
         .filter(books::series_id.eq(id))
-        .order(books::series_order.asc())
+        .order((
+            books::series_order.is_null().asc(),
+            books::series_order.asc(),
+            books::title.asc(),
+        ))
         .load::<Book>(conn)
         .map_err(|e| format!("Failed to load series books: {}", e))?;
 
@@ -169,13 +183,17 @@ pub fn assign_book_to_series(book_title: &str, series_id: Option<i32>, series_or
     // Ensure series_order is None when series_id is None to prevent inconsistent state
     let effective_series_order = if series_id.is_some() { series_order } else { None };
 
-    diesel::update(books::table.find(book_title))
+    let affected = diesel::update(books::table.find(book_title))
         .set((
             books::series_id.eq(series_id),
             books::series_order.eq(effective_series_order),
         ))
         .execute(conn)
         .map_err(|e| format!("Failed to assign book to series: {}", e))?;
+
+    if affected == 0 {
+        return Err(format!("Book '{}' not found or no changes applied", book_title));
+    }
 
     Ok(())
 }

--- a/src-tauri/src/services/series_service.rs
+++ b/src-tauri/src/services/series_service.rs
@@ -162,13 +162,17 @@ pub fn delete_series(id: i32) -> Result<(), String> {
 }
 
 /// Assign a book to a series with a specific order.
+/// Note: If series_id is None, series_order will be set to None to maintain consistency.
 pub fn assign_book_to_series(book_title: &str, series_id: Option<i32>, series_order: Option<i32>) -> Result<(), String> {
     let conn = &mut establish_connection();
+
+    // Ensure series_order is None when series_id is None to prevent inconsistent state
+    let effective_series_order = if series_id.is_some() { series_order } else { None };
 
     diesel::update(books::table.find(book_title))
         .set((
             books::series_id.eq(series_id),
-            books::series_order.eq(series_order),
+            books::series_order.eq(effective_series_order),
         ))
         .execute(conn)
         .map_err(|e| format!("Failed to assign book to series: {}", e))?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
   },
   "productName": "finalshelf",
   "mainBinaryName": "finalshelf",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.finalshelf.app",
   "plugins": {},
   "app": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
   },
   "productName": "finalshelf",
   "mainBinaryName": "finalshelf",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "identifier": "com.finalshelf.app",
   "plugins": {},
   "app": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
   },
   "productName": "finalshelf",
   "mainBinaryName": "finalshelf",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "com.finalshelf.app",
   "plugins": {},
   "app": {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,8 @@ import { LectorsListPageComponent } from "./features/lectors/list/lectors.compon
 import { LectorsDetailsPageComponent } from "./features/lectors/details/lectors-details.component";
 import { GenresListPageComponent } from "./features/genres/list/genres.component";
 import { GenresDetailsPageComponent } from "./features/genres/details/genres-details.component";
+import { SeriesListPageComponent } from "./features/series/list/series.component";
+import { SeriesDetailsPageComponent } from "./features/series/details/series-details.component";
 import { SettingsPageComponent } from "./features/settings/settings.component";
 import { SearchPageComponent } from "./features/search/search.component";
 import { DashboardPageComponent } from "./features/dashboard/dashboard.component";
@@ -57,6 +59,14 @@ export const routes: Routes = [
   {
     path: "genres/:name",
     component: GenresDetailsPageComponent,
+  },
+  {
+    path: "series",
+    component: SeriesListPageComponent,
+  },
+  {
+    path: "series/:id",
+    component: SeriesDetailsPageComponent,
   },
   {
     path: "settings",

--- a/src/app/features/books/details/details.component.html
+++ b/src/app/features/books/details/details.component.html
@@ -65,7 +65,7 @@
                 <a class="details-link" [routerLink]="['/series', currentSeries.id]">
                   {{ currentSeries.name }}
                 </a>
-                <span *ngIf="bookDetails.series_order"> (#{{ bookDetails.series_order }})</span>
+                <span *ngIf="bookDetails.series_order !== null"> (#{{ bookDetails.series_order }})</span>
               </span>
               <span *ngIf="!currentSeries" class="no-series">Not in series</span>
               <button type="button" class="edit-series-btn" (click)="toggleSeriesEditor()" aria-label="Edit series">

--- a/src/app/features/books/details/details.component.html
+++ b/src/app/features/books/details/details.component.html
@@ -58,6 +58,43 @@
           </td>
         </tr>
         <tr>
+          <td class="details-info-label">Series</td>
+          <td class="details-info-value">
+            <div class="series-info">
+              <span *ngIf="currentSeries">
+                <a class="details-link" [routerLink]="['/series', currentSeries.id]">
+                  {{ currentSeries.name }}
+                </a>
+                <span *ngIf="bookDetails.series_order"> (#{{ bookDetails.series_order }})</span>
+              </span>
+              <span *ngIf="!currentSeries" class="no-series">Not in series</span>
+              <button type="button" class="edit-series-btn" (click)="toggleSeriesEditor()" aria-label="Edit series">
+                <img src="assets/icons/settings-svgrepo-com.svg" alt="Edit" />
+              </button>
+            </div>
+            <div *ngIf="showSeriesEditor" class="series-editor">
+              <select [(ngModel)]="selectedSeriesId">
+                <option [ngValue]="null">-- No series --</option>
+                <option *ngFor="let series of availableSeries" [ngValue]="series.id">
+                  {{ series.name }}
+                </option>
+              </select>
+              <input
+                type="number"
+                [(ngModel)]="newSeriesOrder"
+                placeholder="Order #"
+                min="1"
+                class="series-order-input"
+              />
+              <div class="series-editor-actions">
+                <button type="button" (click)="assignToSeries()">Save</button>
+                <button type="button" *ngIf="currentSeries" (click)="removeFromSeries()">Remove</button>
+                <button type="button" (click)="toggleSeriesEditor()">Cancel</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+        <tr>
           <td class="details-info-label">Score</td>
           <td class="details-info-value">
             <div class="star-rating">

--- a/src/app/features/books/details/details.component.html
+++ b/src/app/features/books/details/details.component.html
@@ -97,33 +97,11 @@
         <tr>
           <td class="details-info-label">Score</td>
           <td class="details-info-value">
-            <div class="star-rating">
-              <button
-                *ngFor="let star of stars"
-                type="button"
-                class="star-btn"
-                [attr.aria-label]="'Rate ' + star + ' out of 5'"
-                (click)="setScore(star)"
-                (mouseenter)="hoverScore = star"
-                (mouseleave)="hoverScore = 0"
-              >
-                <img
-                  src="assets/icons/star-svgrepo-com.svg"
-                  alt="Star"
-                  [class.active]="hoverScore >= star || (hoverScore === 0 && bookDetails.score >= star)"
-                />
-              </button>
-              <button
-                type="button"
-                class="clear-score-btn"
-                *ngIf="bookDetails.score > 0"
-                (click)="setScore(0)"
-                aria-label="Clear rating"
-                title="Clear rating"
-              >
-                <img src="assets/icons/close-circle-svgrepo-com.svg" alt="Clear" />
-              </button>
-            </div>
+            <app-score-input
+              [value]="bookDetails.score ?? 0"
+              [max]="6"
+              (valueChange)="onScoreChange($event)"
+            ></app-score-input>
           </td>
         </tr>
       </tbody>

--- a/src/app/features/books/details/details.component.html
+++ b/src/app/features/books/details/details.component.html
@@ -73,7 +73,7 @@
               </button>
             </div>
             <div *ngIf="showSeriesEditor" class="series-editor">
-              <select [(ngModel)]="selectedSeriesId">
+              <select [(ngModel)]="selectedSeriesId" aria-label="Select series">
                 <option [ngValue]="null">-- No series --</option>
                 <option *ngFor="let series of availableSeries" [ngValue]="series.id">
                   {{ series.name }}
@@ -85,6 +85,7 @@
                 placeholder="Order #"
                 min="1"
                 class="series-order-input"
+                aria-label="Series order"
               />
               <div class="series-editor-actions">
                 <button type="button" (click)="assignToSeries()">Save</button>
@@ -99,7 +100,7 @@
           <td class="details-info-value">
             <app-score-input
               [value]="bookDetails.score ?? 0"
-              [max]="6"
+              [max]="10"
               (valueChange)="onScoreChange($event)"
             ></app-score-input>
           </td>

--- a/src/app/features/books/details/details.component.ts
+++ b/src/app/features/books/details/details.component.ts
@@ -2,14 +2,16 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute, RouterModule } from "@angular/router";
 import { invoke } from "@tauri-apps/api/core";
 import { CommonModule } from "@angular/common";
+import { FormsModule } from "@angular/forms";
 import { convertImgPathBook } from "../../../shared/utils/convertImgPath";
 import { getCurrentAbsolutePath } from "../../../shared/utils/getCurrentAbsolutePath";
 import { Book } from "../../../models/books";
+import { Series } from "../../../models/series";
 
 @Component({
   selector: "app-book-details",
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: "./details.component.html",
 })
 export class BookDetailsPageComponent implements OnInit {
@@ -17,6 +19,13 @@ export class BookDetailsPageComponent implements OnInit {
   absolutePath = "";
   hoverScore = 0;
   stars = [1, 2, 3, 4, 5];
+  
+  // Series-related properties
+  currentSeries: Series | null = null;
+  availableSeries: Series[] = [];
+  selectedSeriesId: number | null = null;
+  newSeriesOrder: number | null = null;
+  showSeriesEditor = false;
 
   getSrc = (path: string) => convertImgPathBook(path, this.absolutePath);
 
@@ -40,8 +49,39 @@ export class BookDetailsPageComponent implements OnInit {
       this.bookDetails = await invoke<Book>("get_book_command", {
         title: bookTitle,
       });
+      
+      // Fetch series info if book has a series
+      if (this.bookDetails.series_id) {
+        await this.fetchCurrentSeries(this.bookDetails.series_id);
+      }
+      
+      // Fetch available series for this author
+      if (this.bookDetails.author_name) {
+        await this.fetchAvailableSeries(this.bookDetails.author_name);
+      }
     } catch (error) {
       console.error("Failed to fetch book details:", error);
+    }
+  }
+
+  async fetchCurrentSeries(seriesId: number): Promise<void> {
+    try {
+      const seriesDetails = await invoke<{ series: Series; books: Book[] }>("get_series_command", {
+        id: seriesId,
+      });
+      this.currentSeries = seriesDetails.series;
+    } catch (error) {
+      console.error("Failed to fetch series:", error);
+    }
+  }
+
+  async fetchAvailableSeries(authorName: string): Promise<void> {
+    try {
+      this.availableSeries = await invoke<Series[]>("get_series_by_author_command", {
+        authorName,
+      });
+    } catch (error) {
+      console.error("Failed to fetch available series:", error);
     }
   }
 
@@ -66,6 +106,60 @@ export class BookDetailsPageComponent implements OnInit {
         console.error("Failed to update book score:", error);
         this.bookDetails.score = previousScore;
       }
+    }
+  }
+
+  toggleSeriesEditor(): void {
+    this.showSeriesEditor = !this.showSeriesEditor;
+    if (this.showSeriesEditor && this.bookDetails) {
+      this.selectedSeriesId = this.bookDetails.series_id;
+      this.newSeriesOrder = this.bookDetails.series_order;
+    }
+  }
+
+  async assignToSeries(): Promise<void> {
+    if (!this.bookDetails) return;
+    
+    try {
+      await invoke("assign_book_to_series_command", {
+        bookTitle: this.bookDetails.title,
+        seriesId: this.selectedSeriesId,
+        seriesOrder: this.newSeriesOrder,
+      });
+      
+      // Update local state
+      this.bookDetails.series_id = this.selectedSeriesId;
+      this.bookDetails.series_order = this.newSeriesOrder;
+      
+      // Refresh series info
+      if (this.selectedSeriesId) {
+        await this.fetchCurrentSeries(this.selectedSeriesId);
+      } else {
+        this.currentSeries = null;
+      }
+      
+      this.showSeriesEditor = false;
+    } catch (error) {
+      console.error("Failed to assign book to series:", error);
+    }
+  }
+
+  async removeFromSeries(): Promise<void> {
+    if (!this.bookDetails) return;
+    
+    try {
+      await invoke("assign_book_to_series_command", {
+        bookTitle: this.bookDetails.title,
+        seriesId: null,
+        seriesOrder: null,
+      });
+      
+      this.bookDetails.series_id = null;
+      this.bookDetails.series_order = null;
+      this.currentSeries = null;
+      this.showSeriesEditor = false;
+    } catch (error) {
+      console.error("Failed to remove book from series:", error);
     }
   }
 

--- a/src/app/features/books/details/details.component.ts
+++ b/src/app/features/books/details/details.component.ts
@@ -53,28 +53,19 @@ export class BookDetailsPageComponent implements OnInit {
         title: bookTitle,
       });
       
-      // Fetch series info if book has a series
-      if (this.bookDetails.series_id) {
-        await this.fetchCurrentSeries(this.bookDetails.series_id);
-      }
-      
-      // Fetch available series for this author
+      // Fetch available series for this author first
       if (this.bookDetails.author_name) {
         await this.fetchAvailableSeries(this.bookDetails.author_name);
       }
+      
+      // Derive current series from available series (avoids extra get_series_command call)
+      if (this.bookDetails.series_id) {
+        this.currentSeries = this.availableSeries.find(
+          (s) => s.id === this.bookDetails!.series_id
+        ) ?? null;
+      }
     } catch (error) {
       console.error("Failed to fetch book details:", error);
-    }
-  }
-
-  async fetchCurrentSeries(seriesId: number): Promise<void> {
-    try {
-      const seriesDetails = await invoke<{ series: Series; books: Book[] }>("get_series_command", {
-        id: seriesId,
-      });
-      this.currentSeries = seriesDetails.series;
-    } catch (error) {
-      console.error("Failed to fetch series:", error);
     }
   }
 
@@ -138,12 +129,10 @@ export class BookDetailsPageComponent implements OnInit {
       this.bookDetails.series_id = seriesId;
       this.bookDetails.series_order = seriesOrder;
       
-      // Refresh series info
-      if (seriesId) {
-        await this.fetchCurrentSeries(seriesId);
-      } else {
-        this.currentSeries = null;
-      }
+      // Derive current series from already-loaded availableSeries
+      this.currentSeries = seriesId
+        ? (this.availableSeries.find((s) => s.id === seriesId) ?? null)
+        : null;
       
       this.showSeriesEditor = false;
     } catch (error) {

--- a/src/app/features/books/details/details.component.ts
+++ b/src/app/features/books/details/details.component.ts
@@ -45,6 +45,10 @@ export class BookDetailsPageComponent implements OnInit {
   }
 
   async fetchBookDetails(bookTitle: string): Promise<void> {
+    // Reset state to avoid stale data when navigating between books
+    this.currentSeries = null;
+    this.showSeriesEditor = false;
+    
     try {
       this.bookDetails = await invoke<Book>("get_book_command", {
         title: bookTitle,
@@ -120,20 +124,24 @@ export class BookDetailsPageComponent implements OnInit {
   async assignToSeries(): Promise<void> {
     if (!this.bookDetails) return;
     
+    // Ensure series_order is null when series_id is null
+    const seriesId = this.selectedSeriesId ?? null;
+    const seriesOrder = seriesId ? this.newSeriesOrder : null;
+    
     try {
       await invoke("assign_book_to_series_command", {
         bookTitle: this.bookDetails.title,
-        seriesId: this.selectedSeriesId,
-        seriesOrder: this.newSeriesOrder,
+        seriesId: seriesId,
+        seriesOrder: seriesOrder,
       });
       
       // Update local state
-      this.bookDetails.series_id = this.selectedSeriesId;
-      this.bookDetails.series_order = this.newSeriesOrder;
+      this.bookDetails.series_id = seriesId;
+      this.bookDetails.series_order = seriesOrder;
       
       // Refresh series info
-      if (this.selectedSeriesId) {
-        await this.fetchCurrentSeries(this.selectedSeriesId);
+      if (seriesId) {
+        await this.fetchCurrentSeries(seriesId);
       } else {
         this.currentSeries = null;
       }

--- a/src/app/features/books/details/details.component.ts
+++ b/src/app/features/books/details/details.component.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, RouterModule } from "@angular/router";
 import { invoke } from "@tauri-apps/api/core";
 import { CommonModule } from "@angular/common";
 import { FormsModule } from "@angular/forms";
+import { ScoreInputComponent } from "../../../shared/components/score-input/score-input.component";
 import { convertImgPathBook } from "../../../shared/utils/convertImgPath";
 import { getCurrentAbsolutePath } from "../../../shared/utils/getCurrentAbsolutePath";
 import { Book } from "../../../models/books";
@@ -11,14 +12,12 @@ import { Series } from "../../../models/series";
 @Component({
   selector: "app-book-details",
   standalone: true,
-  imports: [CommonModule, RouterModule, FormsModule],
+  imports: [CommonModule, RouterModule, FormsModule, ScoreInputComponent],
   templateUrl: "./details.component.html",
 })
 export class BookDetailsPageComponent implements OnInit {
   bookDetails: Book | null = null;
   absolutePath = "";
-  hoverScore = 0;
-  stars = [1, 2, 3, 4, 5];
   
   // Series-related properties
   currentSeries: Series | null = null;
@@ -100,16 +99,16 @@ export class BookDetailsPageComponent implements OnInit {
     }
   }
 
-  async setScore(score: number): Promise<void> {
-    if (this.bookDetails) {
-      const previousScore = this.bookDetails.score;
-      this.bookDetails.score = score;
-      try {
-        await invoke("update_book_command", { book: this.bookDetails });
-      } catch (error) {
-        console.error("Failed to update book score:", error);
-        this.bookDetails.score = previousScore;
-      }
+  async onScoreChange(score: number): Promise<void> {
+    if (!this.bookDetails) return;
+
+    const previousScore = this.bookDetails.score;
+    this.bookDetails.score = score;
+    try {
+      await invoke("update_book_command", { book: this.bookDetails });
+    } catch (error) {
+      console.error("Failed to update book score:", error);
+      this.bookDetails.score = previousScore;
     }
   }
 

--- a/src/app/features/series/details/series-details.component.html
+++ b/src/app/features/series/details/series-details.component.html
@@ -1,0 +1,32 @@
+<div class="app-page" *ngIf="seriesDetails">
+  <div class="details-container">
+    <div class="details-info">
+      <h1 class="details-title">{{ seriesDetails.series.name }}</h1>
+      <p class="series-author">
+        by <a [routerLink]="['/authors', seriesDetails.series.author_name]">{{ seriesDetails.series.author_name }}</a>
+      </p>
+      <p class="series-description" *ngIf="seriesDetails.series.description">
+        {{ seriesDetails.series.description }}
+      </p>
+      <p class="series-book-count">{{ seriesDetails.books.length }} books in this series</p>
+    </div>
+  </div>
+
+  <div class="series-books-ordered">
+    <h2>Books in Order</h2>
+    <div class="ordered-list">
+      <div *ngFor="let book of getBooksInOrder(); let i = index" class="ordered-item">
+        <span class="order-number">{{ book.series_order || (i + 1) }}</span>
+        <a [routerLink]="['/books', book.title]" class="book-title">{{ book.title }}</a>
+      </div>
+    </div>
+  </div>
+
+  <h2>All Books</h2>
+  <app-generic-list
+    [items]="seriesDetails.books"
+    listType="books"
+    [paginationEnabled]="false"
+    [sortEnabled]="false"
+  ></app-generic-list>
+</div>

--- a/src/app/features/series/details/series-details.component.html
+++ b/src/app/features/series/details/series-details.component.html
@@ -16,7 +16,7 @@
     <h2>Books in Order</h2>
     <div class="ordered-list">
       <div *ngFor="let book of getBooksInOrder(); let i = index" class="ordered-item">
-        <span class="order-number">{{ book.series_order || (i + 1) }}</span>
+        <span class="order-number">{{ book.series_order ?? (i + 1) }}</span>
         <a [routerLink]="['/books', book.title]" class="book-title">{{ book.title }}</a>
       </div>
     </div>

--- a/src/app/features/series/details/series-details.component.scss
+++ b/src/app/features/series/details/series-details.component.scss
@@ -1,0 +1,64 @@
+.series-author {
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+
+  a {
+    color: var(--color-accent);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.series-description {
+  margin: 1rem 0;
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
+.series-book-count {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.series-books-ordered {
+  margin: 2rem 0;
+
+  h2 {
+    margin-bottom: 1rem;
+  }
+
+  .ordered-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .ordered-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 1rem;
+    background: var(--color-surface);
+    border-radius: 4px;
+
+    .order-number {
+      font-weight: 700;
+      font-size: 1.2rem;
+      color: var(--color-accent);
+      min-width: 2rem;
+      text-align: center;
+    }
+
+    .book-title {
+      color: var(--color-text);
+      text-decoration: none;
+
+      &:hover {
+        color: var(--color-accent);
+      }
+    }
+  }
+}

--- a/src/app/features/series/details/series-details.component.ts
+++ b/src/app/features/series/details/series-details.component.ts
@@ -1,0 +1,44 @@
+import { CommonModule } from "@angular/common";
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute, RouterModule } from "@angular/router";
+import { invoke } from "@tauri-apps/api/core";
+import { SeriesWithBooks } from "../../../models/series";
+import { GenericListComponent } from "../../../shared/components/generic-list/generic-list.component";
+
+@Component({
+  selector: "app-series-details",
+  standalone: true,
+  imports: [CommonModule, RouterModule, GenericListComponent],
+  templateUrl: "./series-details.component.html",
+  styleUrl: "./series-details.component.scss",
+})
+export class SeriesDetailsPageComponent implements OnInit {
+  seriesDetails: SeriesWithBooks | null = null;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe((params) => {
+      const seriesId = params.get("id");
+      if (seriesId) {
+        this.fetchSeriesDetails(parseInt(seriesId, 10));
+      }
+    });
+  }
+
+  async fetchSeriesDetails(seriesId: number): Promise<void> {
+    try {
+      this.seriesDetails = await invoke<SeriesWithBooks>("get_series_command", {
+        id: seriesId,
+      });
+    } catch (error) {
+      console.error("Failed to fetch series details:", error);
+    }
+  }
+
+  getBooksInOrder() {
+    if (!this.seriesDetails) return [];
+    // Books are already ordered by series_order from the backend
+    return this.seriesDetails.books;
+  }
+}

--- a/src/app/features/series/list/series.component.html
+++ b/src/app/features/series/list/series.component.html
@@ -1,0 +1,37 @@
+<div class="app-page">
+  <h1>Series</h1>
+
+  <div class="list-toolbar">
+    <div class="toolbar-pagination">
+      <button (click)="prevPage()" [disabled]="currentPage === 1">
+        <img src="assets/icons/chevron-left-duo-svgrepo-com.svg" alt="Previous" />
+      </button>
+      <select [ngModel]="pageSize" (change)="changePageSize($event)">
+        <option *ngFor="let size of [9, 21, 40, 66, 99]" [value]="size">{{ size }}</option>
+      </select>
+      <button (click)="nextPage()" [disabled]="currentPage === totalPages">
+        <img src="assets/icons/chevron-right-duo-svgrepo-com.svg" alt="Next" />
+      </button>
+    </div>
+    <div class="toolbar-sort">
+      <label for="sort">Sort:</label>
+      <select id="sort" (change)="onSortChange($event)">
+        <option *ngFor="let option of sortOptions" [value]="option">{{ option }}</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="app-grid">
+    <div *ngFor="let series of seriesList" class="grid-item series-item">
+      <a [routerLink]="['/series', series.id]">
+        <span class="series-name">{{ series.name }}</span>
+        <span class="series-author">by {{ series.author_name }}</span>
+        <span class="series-count">{{ series.books_count }} books</span>
+      </a>
+    </div>
+  </div>
+
+  <div *ngIf="!seriesList.length" class="empty">
+    <p>No series found</p>
+  </div>
+</div>

--- a/src/app/features/series/list/series.component.scss
+++ b/src/app/features/series/list/series.component.scss
@@ -1,0 +1,22 @@
+.series-item {
+  a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .series-name {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  .series-author {
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+  }
+
+  .series-count {
+    color: var(--color-text-muted);
+    font-size: 0.85rem;
+  }
+}

--- a/src/app/features/series/list/series.component.ts
+++ b/src/app/features/series/list/series.component.ts
@@ -1,0 +1,84 @@
+import { CommonModule } from "@angular/common";
+import { Component, OnInit } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { FormsModule } from "@angular/forms";
+import { invoke } from "@tauri-apps/api/core";
+import { SeriesListItem, SeriesListResponse } from "../../../models/series";
+
+@Component({
+  selector: "app-series",
+  standalone: true,
+  imports: [CommonModule, RouterModule, FormsModule],
+  templateUrl: "./series.component.html",
+  styleUrl: "./series.component.scss",
+})
+export class SeriesListPageComponent implements OnInit {
+  seriesList: SeriesListItem[] = [];
+  currentPage = 1;
+  pageSize = 21;
+  totalPages = 1;
+  totalCount = 0;
+  sortObject = {
+    "Name ^": ["name", "asc"],
+    "Name v": ["name", "desc"],
+    "Author ^": ["author_name", "asc"],
+    "Author v": ["author_name", "desc"],
+    "Books ^": ["books_count", "asc"],
+    "Books v": ["books_count", "desc"],
+  } as const;
+  sortOptions = Object.keys(this.sortObject);
+  sortIndex: keyof typeof this.sortObject = "Name ^";
+
+  ngOnInit(): void {
+    this.fetchSeries();
+  }
+
+  async fetchSeries(): Promise<void> {
+    try {
+      const response = await invoke<SeriesListResponse>(
+        "get_series_list_command",
+        {
+          params: {
+            page: this.currentPage,
+            limit: this.pageSize,
+            sort_by: this.sortObject[this.sortIndex][0],
+            sort_order: this.sortObject[this.sortIndex][1],
+          },
+        }
+      );
+      this.seriesList = response.items;
+      this.totalPages = response.total_pages;
+      this.totalCount = response.total_count;
+    } catch (error) {
+      console.error("Failed to fetch series:", error);
+    }
+  }
+
+  onPageChange(newPage: number): void {
+    this.currentPage = newPage;
+    this.fetchSeries();
+  }
+
+  onSortChange(event: Event): void {
+    this.sortIndex = (event.target as HTMLSelectElement).value as keyof typeof this.sortObject;
+    this.fetchSeries();
+  }
+
+  changePageSize(event: Event): void {
+    this.pageSize = parseInt((event.target as HTMLSelectElement).value, 10);
+    this.currentPage = 1;
+    this.fetchSeries();
+  }
+
+  prevPage(): void {
+    if (this.currentPage > 1) {
+      this.onPageChange(this.currentPage - 1);
+    }
+  }
+
+  nextPage(): void {
+    if (this.currentPage < this.totalPages) {
+      this.onPageChange(this.currentPage + 1);
+    }
+  }
+}

--- a/src/app/models/books.ts
+++ b/src/app/models/books.ts
@@ -6,7 +6,7 @@ interface Book {
   lector: string;
   create_date: string;
   read: boolean;
-  score: number;
+  score: number | null;
   duration_seconds: number | null;
   series_id: number | null;
   series_order: number | null;

--- a/src/app/models/books.ts
+++ b/src/app/models/books.ts
@@ -8,6 +8,8 @@ interface Book {
   read: boolean;
   score: number;
   duration_seconds: number | null;
+  series_id: number | null;
+  series_order: number | null;
 }
 
 interface ListResponse<T> {

--- a/src/app/models/series.ts
+++ b/src/app/models/series.ts
@@ -1,0 +1,25 @@
+import { Book, ListResponse } from './books';
+
+interface Series {
+  id: number;
+  name: string;
+  author_name: string;
+  description: string | null;
+}
+
+interface SeriesListItem {
+  id: number;
+  name: string;
+  author_name: string;
+  description: string | null;
+  books_count: number;
+}
+
+interface SeriesWithBooks {
+  series: Series;
+  books: Book[];
+}
+
+type SeriesListResponse = ListResponse<SeriesListItem>;
+
+export { Series, SeriesListItem, SeriesWithBooks, SeriesListResponse };

--- a/src/app/models/series.ts
+++ b/src/app/models/series.ts
@@ -1,4 +1,4 @@
-import { Book, ListResponse } from './books';
+import { Book, ListResponse } from "./books";
 
 interface Series {
   id: number;

--- a/src/app/shared/components/generic-list/generic-list.component.html
+++ b/src/app/shared/components/generic-list/generic-list.component.html
@@ -40,8 +40,8 @@
       <img
         [src]="
           listType === 'books'
-            ? getSrc(item.relative_cover_path)
-            : getSrc(item.relative_img_path)
+              ? getSrc(item.relative_cover_path ?? '')
+              : getSrc(item.relative_img_path ?? '')
         "
         [alt]="listType === 'books' ? 'Book cover' : 'Author photo'"
       />

--- a/src/app/shared/components/score-input/score-input.component.html
+++ b/src/app/shared/components/score-input/score-input.component.html
@@ -6,11 +6,13 @@
       class="star-btn"
       [class.active]="hover >= star || (hover === 0 && value >= star)"
       [attr.aria-label]="'Rate ' + star + ' out of ' + max"
+      [disabled]="!editable"
+      [attr.aria-disabled]="!editable || null"
       (click)="setScore(star)"
       (mouseenter)="setHover(star)"
       (mouseleave)="resetHover()"
     >
-      <img src="assets/icons/star-svgrepo-com.svg" alt="Star" />
+      <img src="assets/icons/star-svgrepo-com.svg" alt="" aria-hidden="true" />
     </button>
   </div>
 

--- a/src/app/shared/components/score-input/score-input.component.html
+++ b/src/app/shared/components/score-input/score-input.component.html
@@ -1,0 +1,29 @@
+<div class="score-input">
+  <div class="score-stars">
+    <button
+      *ngFor="let star of stars"
+      type="button"
+      class="star-btn"
+      [class.active]="hover >= star || (hover === 0 && value >= star)"
+      [attr.aria-label]="'Rate ' + star + ' out of ' + max"
+      (click)="setScore(star)"
+      (mouseenter)="setHover(star)"
+      (mouseleave)="resetHover()"
+    >
+      <img src="assets/icons/star-svgrepo-com.svg" alt="Star" />
+    </button>
+  </div>
+
+  <button
+    type="button"
+    class="clear-score-btn"
+    *ngIf="value > 0"
+    (click)="clearScore()"
+    aria-label="Clear rating"
+    title="Clear rating"
+  >
+    <img src="assets/icons/close-circle-svgrepo-com.svg" alt="Clear" />
+  </button>
+
+  <span class="score-text">{{ value > 0 ? value + ' / ' + max : 'Not rated' }}</span>
+</div>

--- a/src/app/shared/components/score-input/score-input.component.scss
+++ b/src/app/shared/components/score-input/score-input.component.scss
@@ -1,0 +1,54 @@
+.score-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.score-stars {
+  display: flex;
+  gap: 4px;
+}
+
+.star-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.star-btn img {
+  width: 20px;
+  height: 20px;
+  opacity: 0.45;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.star-btn.active img {
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.clear-score-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.clear-score-btn img {
+  width: 18px;
+  height: 18px;
+  opacity: 0.7;
+}
+
+.score-text {
+  font-size: 14px;
+  color: #666;
+}

--- a/src/app/shared/components/score-input/score-input.component.scss
+++ b/src/app/shared/components/score-input/score-input.component.scss
@@ -50,5 +50,5 @@
 
 .score-text {
   font-size: 14px;
-  color: #666;
+  color: var(--foreground-alt);
 }

--- a/src/app/shared/components/score-input/score-input.component.ts
+++ b/src/app/shared/components/score-input/score-input.component.ts
@@ -31,6 +31,7 @@ export class ScoreInputComponent {
   }
 
   setHover(star: number): void {
+    if (!this.editable) return;
     this.hover = star;
   }
 

--- a/src/app/shared/components/score-input/score-input.component.ts
+++ b/src/app/shared/components/score-input/score-input.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from "@angular/common";
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+
+@Component({
+  selector: "app-score-input",
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: "./score-input.component.html",
+  styleUrls: ["./score-input.component.scss"],
+})
+export class ScoreInputComponent {
+  @Input() value = 0;
+  @Input() max = 10;
+  @Input() editable = true;
+  @Output() valueChange = new EventEmitter<number>();
+
+  hover = 0;
+
+  get stars(): number[] {
+    return Array.from({ length: this.max }, (_, idx) => idx + 1);
+  }
+
+  setScore(score: number): void {
+    if (!this.editable) return;
+    this.valueChange.emit(score);
+  }
+
+  clearScore(): void {
+    if (!this.editable) return;
+    this.valueChange.emit(0);
+  }
+
+  setHover(star: number): void {
+    this.hover = star;
+  }
+
+  resetHover(): void {
+    this.hover = 0;
+  }
+}

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -37,6 +37,11 @@ export class SidebarComponent {
       label: "Authors",
     },
     {
+      path: ["/series"],
+      icon: "assets/icons/layers-svgrepo-com.svg",
+      label: "Series",
+    },
+    {
       path: ["/lectors"],
       icon: "assets/icons/user-voice-svgrepo-com.svg",
       label: "Lectors",

--- a/src/styles/_details.scss
+++ b/src/styles/_details.scss
@@ -117,3 +117,75 @@
     }
   }
 }
+
+.series-info {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  .no-series {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+
+  .edit-series-btn {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    opacity: 0.5;
+    transition: opacity 0.15s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    img {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+}
+
+.series-editor {
+  margin-top: 0.75rem;
+  padding: 1rem;
+  background: var(--color-surface);
+  border-radius: 0.5rem;
+
+  select,
+  input {
+    padding: 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    background: var(--color-background);
+    color: var(--color-text);
+    margin-right: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .series-order-input {
+    width: 5rem;
+  }
+
+  .series-editor-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+
+    button {
+      padding: 0.5rem 1rem;
+      border: 1px solid var(--color-border);
+      border-radius: 0.25rem;
+      background: var(--color-surface);
+      color: var(--color-text);
+      cursor: pointer;
+      transition: background 0.15s ease;
+
+      &:hover {
+        background: var(--color-accent);
+        color: var(--color-background);
+      }
+    }
+  }
+}

--- a/src/styles/_details.scss
+++ b/src/styles/_details.scss
@@ -136,8 +136,11 @@
     opacity: 0.5;
     transition: opacity 0.15s ease;
 
-    &:hover {
+    &:hover,
+    &:focus-visible {
       opacity: 1;
+      outline: 2px solid var(--color-accent);
+      border-radius: 0.25rem;
     }
 
     img {


### PR DESCRIPTION
## Milestone 2: UI/UX Polish

Implements all 4 stories from M2, adding user preference persistence, interactive book scoring, list filtering, and real-time scan progress feedback.

### Stories

- **2.1 — Persist theme selection**: Selected theme saved to `localStorage` and restored on app startup. Shared constants (`THEME_STORAGE_KEY`, `AVAILABLE_THEMES`) ensure consistency between `AppComponent` and `SettingsPageComponent`.

- **2.2 — Book score editing**: New reusable `ScoreInputComponent` (0–10 star rating with hover, clear, and `aria-label` support). Integrated into book details page with optimistic update and rollback on failure.

- **2.3 — Frontend filters**: Filter controls (author, genre, lector, read status) added to books list page with toggle panel. Filter options populated from backend. Combined filters passed to `get_books_list_command`; page resets on filter change. Active filter badge shown.

- **2.4 — Scan progress feedback**: Backend emits `scan-progress` Tauri events with phase/count/message. Settings page listens and renders a progress bar with current phase and counts. Scan buttons disabled during operation. Completion shown via toast notification.

### Known Issues (non-blocking)
- Tauri event listener in settings runs outside Angular zone — may cause delayed scan progress UI updates
- Score text uses hardcoded `#666` instead of CSS variable `--foreground-alt`
- `prompt()` in `addPath()` remains from M1 Task 1.2.4 (separate scope)
